### PR TITLE
feat[closes #29]: Add a "Legacy Titlebar" toggle to Settings (classic titlebar vs. hover controls)

### DIFF
--- a/data/dev.sinty.desktop.gschema.xml
+++ b/data/dev.sinty.desktop.gschema.xml
@@ -199,6 +199,11 @@
       <summary>Disable Client Side Decorations</summary>
       <description>Forces Server Side Decorations (SSD) by disabling CSD in GTK and Qt apps.</description>
     </key>
+    <key name="legacy-titlebar" type="b">
+      <default>false</default>
+      <summary>Use legacy titlebar</summary>
+      <description>Show a classic static titlebar with inline buttons instead of the floating hover window controls. Ignored when force-ssd is enabled.</description>
+    </key>
     <key name="window-rounded-corners" type="b">
       <default>true</default>
       <summary>Rounded window corners</summary>


### PR DESCRIPTION
Hey Mirko! 👋 This implements the opt-in **Legacy Titlebar** feature from #29 — giving users the choice between the floating hover controls and a classic static titlebar.

Closes #29.

### What this PR does
Adds the `legacy-titlebar` boolean to the `dev.sinty.desktop` schema (default `false`; ignored when `force-ssd` is on). It's the schema key that the render path and the Settings toggle read.

### The feature in one paragraph
When enabled, Singularity apps draw a **classic static titlebar** (real close button + centred title + inline app buttons) instead of the floating hover bubble controls — while staying **client-side decorated**, so the rounded-corner look is fully preserved. It reuses the existing SSD bypass path, so it's a small, low-risk addition rather than a new decoration system. Off by default, so nothing changes unless a user opts in.

### Spread across 3 repos (this is the umbrella)
- 🧩 schema key → **this PR** (closes #29)
- 🪟 window render path → singularityos-lab/libsingularity#4
- 🎛️ Settings toggle → singularityos-lab/singularity-shell#1

Once the two submodule PRs land, the submodule pointers here can be bumped to match (happy to push that follow-up whenever you'd like).

### Open to your direction
You mentioned an adapter would be needed for this — hopefully reusing the SSD bypass keeps it lightweight. If you'd rather shape it differently (e.g. one **Hover / Legacy / System** picker instead of two switches), just say the word and I'll rework it. Thanks for considering it! 🙏
