### PR TITLE
docs: add Debian/Ubuntu deps, aarch64 support note, and vetro bootstrap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,26 @@ sudo dnf install -y \
   libpeas2-devel \
   pipewire-devel
 
+# 2b. ...or install dependencies (Debian / Ubuntu)
+sudo apt install -y \
+  build-essential gettext gobject-introspection gstreamer1.0-pipewire \
+  gstreamer1.0-plugins-good hwdata libadwaita-1-dev libatspi2.0-dev \
+  libcairo2-dev libcmocka-dev libcrypt-dev libdbusmenu-glib-dev libdisplay-info-dev \
+  libdrm-dev libfontconfig-dev libgcrypt20-dev libgdk-pixbuf-2.0-dev \
+  libgee-0.8-dev libgirepository-1.0-dev libglib2.0-bin libglib2.0-dev \
+  libgoa-1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev \
+  libgtk-4-dev libgtk4-layer-shell-dev libgtksourceview-5-dev libgudev-1.0-dev \
+  libinput-dev libjson-glib-dev libliftoff-dev libnm-dev libpam0g-dev \
+  libpango1.0-dev libpeas-2-dev libpipewire-0.3-dev libpixman-1-dev \
+  libpng-dev libpolkit-agent-1-dev libpolkit-gobject-1-dev libpoppler-glib-dev \
+  libpulse-dev librsvg2-dev libseat-dev libsecret-1-dev libsodium-dev \
+  libsoup-3.0-dev libsystemd-dev libtracker-sparql-3.0-dev libupower-glib-dev \
+  libvte-2.91-gtk4-dev libwayland-dev libwebkitgtk-6.0-dev libxcb-composite0-dev \
+  libxcb-dri3-dev libxcb-errors-dev libxcb-ewmh-dev libxcb-icccm4-dev \
+  libxcb-present-dev libxcb-render0-dev libxcb-res0-dev libxcb-xfixes0-dev \
+  libxcb1-dev libxkbcommon-dev libxml2-dev meson ninja-build pkg-config \
+  sassc scdoc valac wayland-protocols xwayland
+
 # 3. Build
 meson setup build
 ninja -C build
@@ -44,6 +64,39 @@ Optional runtime: install `appmenu-gtk-module` (Debian/Ubuntu
 third-party GTK apps publish their menu bar to the panel global menu. First-party
 apps do not need it. Firefox only exports its menu over X11, so its global menu
 shows only under XWayland (`MOZ_ENABLE_WAYLAND=0`).
+
+---
+
+## Architecture support
+
+Singularity builds and runs on both **x86_64** and **aarch64 (arm64)**. The aarch64
+build needs no source changes and no architecture guards — the C Wayland bindings, the
+Vala shell, `libsingularity`, the portal and the bundled labwc/wlroots all compile as-is.
+
+Verified on the CIX Sky1 (CD8180) SoC in an `ubuntu:26.04` aarch64 container:
+
+```
+Host machine cpu family: aarch64
+Host machine cpu: aarch64
+C compiler: gcc 15.2.0
+Vala compiler: valac 0.56.18
+Meson: 1.10.1
+```
+
+---
+
+## Building vetro (UI transpiler host tool)
+
+`subprojects/singularity-calculator`, `singularity-calendar` and `singularity-demo`
+transpile their `.vetro` UI files to `.ui` at build time via `find_program('vetro')`.
+That lookup is mandatory, so if your distribution has no `vetro` package the build fails
+at `meson setup`. Build it from source (needs Go 1.24+) and put it on `PATH` first:
+
+```bash
+git clone https://github.com/singularityos-lab/vetro
+cd vetro && go build -o vetro .
+install -Dm755 vetro ~/.local/bin/vetro   # ensure ~/.local/bin is on PATH
+```
 
 ---
 


### PR DESCRIPTION
## Summary

The Quick Start covers Fedora/Silverblue only, so a Debian or Ubuntu builder has to reverse-engineer the dependency names. Three gaps came up bringing Singularity up on a Debian arm64 distro; this fills all three. Docs only — the Fedora block is untouched.

**1. An apt dependency list.** Not a mechanical translation of the `dnf` list — this is the exact set that completed a full workspace build (top project plus bundled labwc/wlroots) in an `ubuntu:26.04` **aarch64** container. It includes several things the dnf list doesn't name explicitly (`libsoup-3.0-dev`, `gobject-introspection`, `libupower-glib-dev`, `libnm-dev`, `libgoa-1.0-dev`, `sassc`, `scdoc`, `hwdata`) that the build does need.

**2. An architecture support statement.** The tree is already architecture-clean — no arch guards, no `#ifdef __aarch64__`, no arch-specific meson logic, no source changes. But there's currently nothing saying so, and the natural assumption on a non-x86 board is that porting work is required. Toolchain versions from the verified build are recorded.

**3. A `vetro` bootstrap.** This one is a hard blocker rather than a nicety:

```
subprojects/singularity-calculator/ui/meson.build:1:vetro = find_program('vetro')
subprojects/singularity-calendar/ui/meson.build:1:vetro = find_program('vetro')
```

`find_program()` with no `required: false` is fatal, and `vetro` has no distro package — so on any distro without it, `meson setup` fails before compiling anything, and the fix (clone a separate Go repo and put the binary on `PATH`) isn't discoverable from the docs.

## Validation

- Full workspace build completed on aarch64 with exactly this dependency set; `meson install` produced a complete tree (`bin/ include/ lib/ libexec/ share/`).
- `vetro` built from source with `go build` and picked up by `find_program('vetro')`.
- Verified on Debian arm64 / CIX Sky1 (CD8180), Radxa Orion O6N.

Package names are for Debian 13 / Ubuntu 26.04. On older releases `libgtk4-layer-shell-dev` and `libpeas-2-dev` may be named differently or need a backport — happy to add a note to that effect if you'd like.

## Compatibility

Purely additive documentation. No build, meson, or source changes.

## Rollback

Revert the single docs commit.
