### PR TITLE
docs: note GLES-only / no-Vulkan GPU support

### DIFF
--- a/docs/gpu-support.md
+++ b/docs/gpu-support.md
@@ -1,0 +1,44 @@
+# GPU and renderer support
+
+Singularity does **not** require Vulkan. It runs on GLES-only GPUs — for example Arm
+Mali parts driven by `libmali`, which expose GLES 3.x and no Vulkan driver at all.
+
+Two independent renderer decisions make this work, and both already default correctly:
+
+1. **GTK4 (shell and apps).** `singularity-desktop-session` sets `GSK_RENDERER=gl`, so
+   GTK uses its GL renderer and never requests the Vulkan (`ngl`) path.
+
+2. **wlroots (labwc's compositor backend).** wlroots auto-selects a renderer and falls
+   back to GLES2 when no Vulkan renderer is available.
+
+So a GLES-only GPU needs no configuration, no override and no source changes.
+
+## Verified configuration
+
+A full session (labwc + shell + apps) running on Arm **Mali-G720** (CIX Sky1 CD8180,
+GLES 3.x, no Vulkan driver present), aarch64. GLES2 was auto-selected; no `WLR_RENDERER`
+override was needed.
+
+## Forcing a renderer
+
+wlroots and GTK both read their renderer choice from the environment, so nothing in
+Singularity needs to be changed to pin one:
+
+```bash
+WLR_RENDERER=gles2 GSK_RENDERER=gl singularity-labwc-session
+```
+
+Note that `singularity-labwc-session` already has a software-rendering safety net: if the
+session exits within 30 seconds it retries once with `GSK_RENDERER=cairo`,
+`WLR_RENDERER=pixman`, `LIBGL_ALWAYS_SOFTWARE=1` and `GALLIUM_DRIVER=llvmpipe`, so an
+early crash on the hardware GL path still lands you at a usable desktop (see #78). If you
+find yourself in a software session unexpectedly, check the labwc log for that retry line
+before assuming your GPU is unsupported.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Session starts, then everything is slow | The #78 fallback fired — grep the labwc log for `retrying with software rendering` |
+| Compositor fails to start on a GLES-only GPU | Confirm the GLES driver is actually loading; try `WLR_RENDERER=gles2` explicitly |
+| GTK apps fail but the compositor is fine | A GTK-side renderer issue, not wlroots — try `GSK_RENDERER=cairo` |


### PR DESCRIPTION
## Summary

Adds `docs/gpu-support.md` stating that Singularity runs on GLES-only GPUs with no Vulkan driver, and recording a verified configuration.

Nothing currently says whether a GPU without Vulkan is supported. It **is** — but that has to be inferred by reading the session script and knowing what wlroots does, so the natural assumption on a GLES-only board is that the desktop won't come up. That's the whole gap this closes.

The two relevant decisions both already default correctly:

- `singularity-desktop-session` sets `GSK_RENDERER=gl`, so GTK4 never requests the Vulkan (`ngl`) path.
- wlroots auto-selects GLES2 when no Vulkan renderer is present.

So a GLES-only GPU needs no configuration, no override, and no source changes.

## No code change

An earlier version of this added a `WLR_RENDERER` passthrough to `singularity-labwc-session`. I dropped it — wlroots reads `WLR_RENDERER` from the environment already, so the passthrough is redundant, and `singularity-labwc-session` now has the #78 software-rendering retry which sets `WLR_RENDERER=pixman` itself. A second mechanism touching the same variable would only add confusion.

The page documents that #78 retry instead, because it's easy to hit without noticing: if the session dies inside 30s you land in a software session that looks like poor GPU support rather than a crash fallback. The troubleshooting table points at the log line to check first.

## Placement

Put in `docs/` as a standalone page rather than in `CONTRIBUTING.md`, since it's user/integrator-facing rather than contributor-facing — and so it doesn't collide with #233, which edits `CONTRIBUTING.md`. Happy to move or link it from wherever you'd prefer.

## Validation

Full session (labwc + shell + apps) running on Arm **Mali-G720** (CIX Sky1 CD8180, GLES 3.x, aarch64) with no Vulkan driver present. GLES2 auto-selected; no `WLR_RENDERER` override needed; `GSK_RENDERER=gl` confirmed in effect.

## Compatibility

Additive documentation only — new file, nothing modified.

## Rollback

Revert the single commit.
