### PR TITLE
feat(schema): add night light GSettings keys

### DIFF
--- a/data/dev.sinty.desktop.gschema.xml
+++ b/data/dev.sinty.desktop.gschema.xml
@@ -149,6 +149,32 @@
       <summary>Adaptive Night End</summary>
       <description>Time of day (HH:MM) at which the adaptive theme returns to the chosen day mode.</description>
     </key>
+    <key name="night-light-enabled" type="b">
+      <default>false</default>
+      <summary>Night Light</summary>
+      <description>Whether the warm night-light color temperature is applied.</description>
+    </key>
+    <key name="night-light-temperature" type="i">
+      <default>4000</default>
+      <range min="1000" max="6500"/>
+      <summary>Night Light Temperature</summary>
+      <description>Color temperature in Kelvin applied while night light is active.</description>
+    </key>
+    <key name="night-light-adaptive" type="b">
+      <default>false</default>
+      <summary>Adaptive Night Light</summary>
+      <description>When enabled, night light follows a daily schedule instead of a manual switch.</description>
+    </key>
+    <key name="night-light-adaptive-from" type="s">
+      <default>'19:00'</default>
+      <summary>Night Light Start</summary>
+      <description>Time of day (HH:MM) at which adaptive night light turns on.</description>
+    </key>
+    <key name="night-light-adaptive-to" type="s">
+      <default>'07:00'</default>
+      <summary>Night Light End</summary>
+      <description>Time of day (HH:MM) at which adaptive night light turns off.</description>
+    </key>
     <key name="developer-mode" type="b">
       <default>false</default>
       <summary>Developer Mode</summary>


### PR DESCRIPTION
## What

Adds five keys to the `dev.sinty.desktop` schema backing the new settings-driven night light:

| Key | Type | Default | Notes |
|---|:---:|---:|---|
| `night-light-enabled` | `b` | `false` | Master switch |
| `night-light-temperature` | `i` | `4000` | Kelvin, range 1000–6500 |
| `night-light-adaptive` | `b` | `false` | Schedule-based mode |
| `night-light-adaptive-from` | `s` | `'19:00'` | `HH:MM` |
| `night-light-adaptive-to` | `s` | `'07:00'` | `HH:MM` |

Keys follow the existing `theme-adaptive*` pattern: the same `HH:MM` schedule model, including support for overnight spans.

The schema change is required before the `libsingularity` manager update can read these settings. The UI follows in `singularity-shell`.

## Why

Night light is currently a hard-coded on/off toggle at 4000 K, with no persistence, temperature control, or scheduling.
