### PR TITLE
schema: add artist-pack-apt-sources key for the Artist Pack browser

### DIFF
--- a/data/dev.sinty.desktop.gschema.xml
+++ b/data/dev.sinty.desktop.gschema.xml
@@ -120,6 +120,20 @@
       <default>[]</default>
       <summary>List of recently used wallpaper URIs</summary>
     </key>
+    <key name="artist-pack-apt-sources" type="as">
+      <default>[]</default>
+      <summary>Artist Pack apt sources</summary>
+      <description>List of apt repository base URIs treated as sources of
+        curated Artist Packs (ncz-wallpapers-* debs) by the Desktop settings'
+        Artist Pack browser. Only packages whose apt candidate URI is under
+        one of these bases are listed for browsing/installing. Empty means no
+        source is trusted, so the browser shows nothing rather than silently
+        trusting an unconfigured repository. Distributions set this via a
+        packaged gschema override (see dev.sinty.desktop.gschema.override in
+        the distro's post-install), not by patching this default -- the whole
+        point is that the trusted source list is deployment configuration,
+        not something baked into the browser's code.</description>
+    </key>
     <key name="custom-shortcuts" type="a{ss}">
       <default>{}</default>
       <summary>Map of action names to custom accelerator strings</summary>


### PR DESCRIPTION
## Summary

Adds the `artist-pack-apt-sources` (`as`) key to
`data/dev.sinty.desktop.gschema.xml`, matching this schema's existing
convention (`background-picture-uri`, `recent-wallpapers`, `pinned-apps`,
...).

This is the config surface for a curated wallpaper "Artist Pack" browser
landing in `singularity-shell` (companion PR there): which apt source(s)
count as an artist-pack source is deployment configuration, read at
runtime by that feature's backend scripts, never a literal baked into UI
or script code. The default is an empty list, meaning no source is
trusted out of the box — a distro sets this via a packaged
`.gschema.override`, the same mechanism already used for accent color,
dark mode, and wallpaper defaults.

## Test plan

- [x] `data/dev.sinty.desktop.gschema.xml` parses and
      `glib-compile-schemas --strict` accepts the new key.
- [x] A `.gschema.override` setting `artist-pack-apt-sources` compiles
      clean under `--strict`.
- [x] The SAME override, against the schema WITHOUT this patch, compiles
      clean under a plain (non-`--strict`) invocation with the unknown key
      silently ignored, and correctly FAILS under `--strict` — confirming a
      distro can ship its override ahead of this patch landing without
      breaking the existing overrides it sits next to.

## Compatibility

Additive schema key only, default `[]`. No behavior change for any
existing consumer of this schema.
